### PR TITLE
fix: Phase5レビュー指摘対応 - IMPLEMENTATION_STATUS・機能責務一覧の実装不一致を修正

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -110,9 +110,9 @@
 - [x] src/components/SettingsModal.tsx - 設定モーダル
   - モーダルオーバーレイ（rgba(0,0,0,0.5)）
   - データ管理セクション
-    - プロフィールデータ削除
-    - 案件データ削除
-    - 分析結果削除
+    - プロファイルデータ削除（プロフィール情報・生成プロフィール文）
+    - 案件データ削除（案件情報・分析結果・分析履歴の一括削除）
+    - 応募文データ削除（作成した応募文・チャット履歴）
   - 全データ削除（APIキー除く）
   - 削除確認ダイアログ
 
@@ -176,11 +176,19 @@
 
 ## ストレージキー
 
-すべてのキーは `aijobinsight_` プレフィックス付き:
-- `aijobinsight_apiConfig` - API設定
-- `aijobinsight_profile` - プロフィールデータ
-- `aijobinsight_job` - 案件データ
-- `aijobinsight_analysisResult` - 分析結果
+すべてのキーは `aijobinsight_` プレフィックス付き（`STORAGE_KEYS` 定義による）:
+- `aijobinsight_api_key_config` - API設定
+- `aijobinsight_profile_data` - プロフィールデータ
+- `aijobinsight_generated_profile` - 生成プロフィール文
+- `aijobinsight_job_data` - 案件データ
+- `aijobinsight_analysis_result` - 分析結果
+- `aijobinsight_analysis_history` - 分析履歴
+- `aijobinsight_application_text` - 応募文（旧）
+- `aijobinsight_application_drafts` - 案件ごとの応募文
+- `aijobinsight_application_chat_histories` - 案件ごとのチャット履歴
+- `aijobinsight_templates` - テンプレート
+- `aijobinsight_planned_applications` - 応募予定案件
+- `aijobinsight_settings` - 設定
 
 ## 開発環境
 

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -35,11 +35,18 @@
   - removeStorageItem: データ削除
   - clearStorageByPrefix: プレフィックスでデータクリア
 
-### サービス (src/services/)
-- [x] src/services/aiService.ts - AI API統合
-  - analyzeJob: 案件分析実行（OpenAI/Gemini）
-  - chatWithAI: チャット実行（OpenAI/Gemini）
-  - JSON応答形式の処理
+### サービス (src/core/ai/, src/domains/job/services/)
+> ⚠️ Phase 3 リファクタリングにより `src/services/aiService.ts` は削除済み。機能は以下に分散移管。
+
+- [x] src/core/ai/ - 共通AI通信基盤
+  - client.ts: AI通信処理（callAI, callAIChat、30秒タイムアウト）
+  - transform.ts: AI応答整形処理（transformAIResponse、JSONブロック抽出）
+  - types.ts: AI共通型定義（AIService, ChatMessage, AIClientRequest等）
+  - index.ts: エントリーポイント
+- [x] src/domains/job/services/ - Job固有サービス層
+  - jobAnalysisService.ts: 案件分析サービス（analyzeJob）
+  - jobChatService.ts: チャットサービス（chatWithAI）
+  - jobProfileService.ts: プロフィール生成サービス（generateProfileText）
 
 ### カスタムフック (src/hooks/)
 - [x] src/hooks/useLocalStorage.ts - localStorage連携フック
@@ -71,10 +78,7 @@
   - 自動保存
 
 - [x] src/components/JobInput.tsx - 案件入力
-  - 案件説明（textarea, 5行, 必須）
-  - 業務内容（textarea, 5行, 必須）
-  - 必須要件（textarea, 4行, 必須）
-  - 報酬（text, 必須）
+  - 案件説明（textarea, 10行, 必須）※案件情報を一括コピー&ペースト入力
   - 案件URL（url, 任意）
   - メモ（textarea, 3行, 任意）
   - 自動保存
@@ -85,12 +89,13 @@
   - 無効化状態（データ未入力時）
   - クリックハンドラー
 
-- [x] src/components/AnalysisResult.tsx - 分析結果表示
-  - 星評価（1〜5）
+- [x] src/domains/job/components/JobAnalysisResult.tsx - 分析結果表示（Phase 4 にて移管）
+  - 星評価（StarRating 共通コンポーネント使用）
   - 強み（緑色チェックマーク）
   - 懸念点（黄色警告アイコン）
-  - スキルマッチ度（プログレスバー）
-  - 応募戦略（青背景ハイライト）
+  - スキルマッチ度（RadarChart 共通コンポーネント使用）
+  - 応募戦略（ResultCard 共通コンポーネント使用）
+> ⚠️ `src/components/AnalysisResult.tsx` は Phase 4 で削除済み
 
 #### 対話系
 - [x] src/components/ChatInterface.tsx - チャットインターフェース

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -176,19 +176,32 @@
 
 ## ストレージキー
 
-すべてのキーは `aijobinsight_` プレフィックス付き（`STORAGE_KEYS` 定義による）:
+`src/utils/storage.ts` の `STORAGE_KEYS` 定義による全キー一覧:
+
+### 通常キー（プレフィックス: `aijobinsight_`）
 - `aijobinsight_api_key_config` - API設定
 - `aijobinsight_profile_data` - プロフィールデータ
 - `aijobinsight_generated_profile` - 生成プロフィール文
 - `aijobinsight_job_data` - 案件データ
 - `aijobinsight_analysis_result` - 分析結果
 - `aijobinsight_analysis_history` - 分析履歴
-- `aijobinsight_application_text` - 応募文（旧）
+- `aijobinsight_analysis_active_tab` - 案件分析ページのアクティブタブ
+- `aijobinsight_analysis_chat_histories` - 案件分析ページの案件ごとのチャット履歴
+- `aijobinsight_application_text` - 応募文（旧・後方互換用）
 - `aijobinsight_application_drafts` - 案件ごとの応募文
 - `aijobinsight_application_chat_histories` - 案件ごとのチャット履歴
+- `aijobinsight_application_text_generic` - 汎用スロットの応募文
+- `aijobinsight_application_generic_chat` - 汎用スロットのチャット履歴
+- `aijobinsight_application_linked_mode` - 連動モードのトグル状態
+- `aijobinsight_current_job_index` - 現在の案件インデックス
+- `aijobinsight_linked_job_info` - 連動中の案件情報
 - `aijobinsight_templates` - テンプレート
 - `aijobinsight_planned_applications` - 応募予定案件
 - `aijobinsight_settings` - 設定
+
+### デモモード用キー（プレフィックス: `aijobinsight_demo_`）
+- `aijobinsight_demo_profile` - デモ用プロフィールデータ
+- `aijobinsight_demo_history` - デモ用履歴データ
 
 ## 開発環境
 

--- a/docs/development/共通基盤リファクタリング_機能責務一覧.md
+++ b/docs/development/共通基盤リファクタリング_機能責務一覧.md
@@ -27,9 +27,11 @@ AI Job Insightの共通基盤リファクタリング（Issue #20, Phase 1）に
 - OpenAI API
 - Google Gemini API
 
-**実装場所（想定）**
+**実装場所**
 - `src/core/ai/client.ts`
-- `src/core/ai/config.ts`
+- `src/core/ai/transform.ts`
+- `src/core/ai/types.ts`
+- `src/core/ai/index.ts`
 
 **入力パラメータ（汎用）**
 - service: 'openai' | 'gemini'


### PR DESCRIPTION
## 概要

PR #30（Phase 5）のレビュー指摘事項に対する追補修正です。

> ⚠️ **謝罪:** PR #30 においてセルフレビューのみでマージしてしまいました。今後はマージ前にレビュー担当者への確認を徹底いたします。

---

## 修正内容

### 第1次レビュー指摘

#### 指摘1（中）: `IMPLEMENTATION_STATUS.md` — 削除済み `aiService.ts` の記載
- `src/services/aiService.ts` → `⚠️削除済み` 注記を付け、`src/core/ai/` + `src/domains/job/services/` の実構成に差し替え

#### 指摘2（中）: `IMPLEMENTATION_STATUS.md` — JobInput 入力項目が旧仕様
- 業務内容・必須要件・報酬の3フィールド → 現行実装（案件説明10行・一括コピー&ペースト）に更新

#### 指摘3（中）: `IMPLEMENTATION_STATUS.md` — 削除済み `AnalysisResult.tsx` の記載
- `src/components/AnalysisResult.tsx` → `⚠️削除済み` 注記を付け、`src/domains/job/components/JobAnalysisResult.tsx` に差し替え

#### 指摘4（低）: `共通基盤リファクタリング_機能責務一覧.md` — 実在しない `config.ts`
- `src/core/ai/config.ts` を削除し、実在する `transform.ts` / `types.ts` / `index.ts` に差し替え
- 「実装場所（想定）」→「実装場所」に修正

---

### 第2次レビュー指摘

#### 指摘1（中）: `IMPLEMENTATION_STATUS.md` — 設定モーダル機能記載不整合
- Before: プロフィールデータ削除 / 案件データ削除 / **分析結果削除**（3項目）
- After: プロフィールデータ削除（プロフィール情報・生成プロフィール文） / **案件データ削除（案件情報・分析結果・分析履歴の一括削除）** / **応募文データ削除（作成した応募文・チャット履歴）** に差し替え

#### 指摘2（低）: `IMPLEMENTATION_STATUS.md` — ストレージキー一覧が旧キー名
- Before: `aijobinsight_apiConfig` / `aijobinsight_profile` / `aijobinsight_job` / `aijobinsight_analysisResult`（4キー）
- After: `storage.ts` の `STORAGE_KEYS` 定義に合わせて現行12キー（`api_key_config` / `profile_data` / `generated_profile` / `job_data` / `analysis_result` / `analysis_history` / `application_drafts` 等）に差し替え

---
